### PR TITLE
🐞 Fix some typos

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -169,7 +169,7 @@ class Contact extends AbstractModel
     /**
      * @return string|null
      */
-    public function geAdresse(): ?string
+    public function getAdresse(): ?string
     {
         return $this->get('adresse');
     }
@@ -207,9 +207,9 @@ class Contact extends AbstractModel
     }
 
     /**
-     * @return bool
+     * @return bool|null
      */
-    public function getNewsletterOptin(): bool
+    public function getNewsletterOptin(): ?bool
     {
         return $this->get('newsletter_optin');
     }

--- a/src/Model/ContactsCreateOrUpdateRequest.php
+++ b/src/Model/ContactsCreateOrUpdateRequest.php
@@ -266,7 +266,7 @@ class ContactsCreateOrUpdateRequest extends AbstractModel
      * @param string|null $nomNaissance
      * @return self
      */
-    public function seNomNaissance(?string $nomNaissance): self
+    public function setNomNaissance(?string $nomNaissance): self
     {
         return $this->set('nom_naissance', $nomNaissance);
     }

--- a/src/Model/Lap.php
+++ b/src/Model/Lap.php
@@ -63,7 +63,7 @@ class Lap extends AbstractModel
     /**
      * @return string|null
      */
-    public function getSources(): ?string
+    public function getSource(): ?string
     {
         return $this->get('source');
     }

--- a/tests/Unit/Service/LapsTest.php
+++ b/tests/Unit/Service/LapsTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\Attributes\TestWith;
 #[CoversMethod(Laps::class, 'delete')]
 #[CoversMethod(Laps::class, 'findById')]
 #[CoversMethod(Laps::class, 'find')]
-#[CoversMethod(Lap::class, 'getSources')]
+#[CoversMethod(Lap::class, 'getSource')]
 #[CoversMethod(Lap::class, 'getIdParticipant')]
 #[CoversMethod(Lap::class, 'getParticipant')]
 class LapsTest extends ServiceTestCase

--- a/tests/Unit/Service/LapsTest.php
+++ b/tests/Unit/Service/LapsTest.php
@@ -77,7 +77,7 @@ class LapsTest extends ServiceTestCase
 
         $this->assertInstanceOf(Lap::class, $result);
         $this->assertInstanceOf(Participant::class, $result->getParticipant());
-        $this->assertEquals('dendreo', $result->getSources());
+        $this->assertEquals('dendreo', $result->getSource());
         $this->assertEquals(15, $result->getIdParticipant());
     }
 


### PR DESCRIPTION
Fix typos in model getters/setters and incorrect return type.

- Fix geAdresse() → getAdresse() typo in Contact model (missing t)
- Fix getSources() → getSource() typo in Lap model (incorrect plural)
- Fix seNomNaissance() → setNomNaissance() typo in ContactsCreateOrUpdateRequest (missing t — this one broke deserialization of the nom_naissance field via ObjectSerializer)
- Fix getNewsletterOptin() return type from bool to ?bool since get() can return null
- Update LapsTest to use the corrected getSource() method name  